### PR TITLE
Update scripts to allow for directories with spaces.

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -44,7 +44,7 @@ function applyPatch {
         mkdir "$basedir/$target"
         cd "$basedir/$target"
         git init
-        git remote add origin $5
+        git remote add origin "$5"
         cd "$basedir"
     fi
     cd "$basedir/$target"
@@ -56,7 +56,7 @@ function applyPatch {
 
     echo "Resetting $target to $what_name..."
     git remote rm upstream > /dev/null 2>&1
-    git remote add upstream $basedir/$what >/dev/null 2>&1
+    git remote add upstream "$basedir/$what" >/dev/null 2>&1
     git checkout master 2>/dev/null || git checkout -b master
     git fetch upstream >/dev/null 2>&1
     git reset --hard upstream/upstream

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -8,13 +8,13 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 . $(dirname $SOURCE)/init.sh
 
-workdir=$basedir/Paper/work
-minecraftversion=$(cat $basedir/Paper/work/BuildData/info.json | grep minecraftVersion | cut -d '"' -f 4)
+workdir="$basedir"/Paper/work
+minecraftversion=$(cat "$basedir"/Paper/work/BuildData/info.json | grep minecraftVersion | cut -d '"' -f 4)
 decompiledir=$workdir/Minecraft/$minecraftversion/spigot
 
 nms="net/minecraft/server"
 export MODLOG=""
-cd $basedir
+cd "$basedir"
 
 function containsElement {
     local e

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -9,7 +9,7 @@ MCDEV_REPO=""
 # END config
 
 sourceBase=$(dirname $SOURCE)/../
-cd ${basedir:-$sourceBase}
+cd "${basedir:-$sourceBase}"
 
 basedir=$(pwd -P)
 cd -

--- a/scripts/upstream.sh
+++ b/scripts/upstream.sh
@@ -32,14 +32,14 @@ cd "Paper-Server"
 mcVer=$(mvn -o org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=minecraft_version | sed -n -e '/^\[.*\]/ !{ /^[0-9]/ { p; q } }')
 
 basedir
-. $basedir/scripts/importmcdev.sh
+. "$basedir"/scripts/importmcdev.sh
 
-minecraftversion=$(cat $basedir/Paper/work/BuildData/info.json | grep minecraftVersion | cut -d '"' -f 4)
+minecraftversion=$(cat "$basedir"/Paper/work/BuildData/info.json | grep minecraftVersion | cut -d '"' -f 4)
 version=$(echo -e "Paper: $paperVer\nmc-dev:$importedmcdev")
 tag="${minecraftversion}-${mcVer}-$(echo -e $version | shasum | awk '{print $1}')"
-echo "$tag" > $basedir/current-paper
+echo "$tag" > "$basedir"/current-paper
 
-$basedir/scripts/generatesources.sh
+"$basedir"/scripts/generatesources.sh
 
 cd Paper/
 
@@ -56,7 +56,7 @@ echo "Tagging as $tag"
 echo -e "$version"
 
 forcetag=0
-if [ "$(cat $basedir/current-paper)" != "$tag" ]; then
+if [ "$(cat "$basedir"/current-paper)" != "$tag" ]; then
     forcetag=1
 fi
 

--- a/tuinity
+++ b/tuinity
@@ -9,7 +9,7 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 SOURCE=$([[ "$SOURCE" = /* ]] && echo "$SOURCE" || echo "$PWD/${SOURCE#./}")
 basedir=$(dirname "$SOURCE")
-. $basedir/scripts/init.sh
+. "$basedir"/scripts/init.sh
 
 paperstash() {
     STASHED=$(git stash)


### PR DESCRIPTION
The title pretty much explains all.
I have (quite painfully) tested the scripts with a directory that contains spaces and it does compile on my local machine (using git on windows).
If I missed any areas, please let me know. I am also by no means a bash expert, so if I fajangled something, also let me know.