### PR TITLE
./tuinity : exit immediately if a command exits with a non-zero status

### DIFF
--- a/tuinity
+++ b/tuinity
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# exit immediately if a command exits with a non-zero status
+set -e
 # get base dir regardless of execution location
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink


### PR DESCRIPTION
Without this line, the script always success even if compilation fails