### PR TITLE
Update version fetcher repo to Tuinity's

### DIFF
--- a/patches/server/0029-Update-version-fetcher-repo.patch
+++ b/patches/server/0029-Update-version-fetcher-repo.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Update version fetcher repo
 Sets the target github repo to Tuinity in the version checker. Also disables the jenkins build lookups.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
-index 49a38c6608b652ff48ef4eaca0dd3ccb1ba570e3..fff982f4d21087324fdc2f7cd1ebca6cbe378752 100644
+index 49a38c6608b652ff48ef4eaca0dd3ccb1ba570e3..79210052799b21e369f67b5932c4807a394cf08a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 @@ -24,8 +24,8 @@ public class PaperVersionFetcher implements VersionFetcher {
@@ -20,15 +20,19 @@ index 49a38c6608b652ff48ef4eaca0dd3ccb1ba570e3..fff982f4d21087324fdc2f7cd1ebca6c
          String history = getHistory();
  
          return history != null ? history + "\n" + updateMessage : updateMessage;
-@@ -50,6 +50,11 @@ public class PaperVersionFetcher implements VersionFetcher {
+@@ -49,13 +49,10 @@ public class PaperVersionFetcher implements VersionFetcher {
+ 
      private static String getUpdateStatusMessage(@Nonnull String repo, @Nonnull String branch, @Nonnull String versionInfo) {
          int distance;
-         try {
-+            // Tuinity start
-+            if (true) {
-+                throw new NumberFormatException();
-+            }
-+            // Tuinity end
-             int jenkinsBuild = Integer.parseInt(versionInfo);
-             distance = fetchDistanceFromSiteApi(jenkinsBuild, getMinecraftVersion());
-         } catch (NumberFormatException ignored) {
+-        try {
+-            int jenkinsBuild = Integer.parseInt(versionInfo);
+-            distance = fetchDistanceFromSiteApi(jenkinsBuild, getMinecraftVersion());
+-        } catch (NumberFormatException ignored) {
++        // Tuinity start
+             versionInfo = versionInfo.replace("\"", "");
+             distance = fetchDistanceFromGitHub(repo, branch, versionInfo);
+-        }
++        // Tuinity end
+ 
+         switch (distance) {
+             case -1:

--- a/patches/server/0029-Update-version-fetcher-repo.patch
+++ b/patches/server/0029-Update-version-fetcher-repo.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: JRoy <joshroy126@gmail.com>
+Date: Thu, 19 Mar 2020 20:32:56 -0400
+Subject: [PATCH] Update version fetcher repo
+
+Sets the target github repo to Tuinity in the version checker. Also disables the jenkins build lookups.
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
+index 49a38c6608b652ff48ef4eaca0dd3ccb1ba570e3..fff982f4d21087324fdc2f7cd1ebca6cbe378752 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
++++ b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
+@@ -24,8 +24,8 @@ public class PaperVersionFetcher implements VersionFetcher {
+     @Nonnull
+     @Override
+     public String getVersionMessage(@Nonnull String serverVersion) {
+-        String[] parts = serverVersion.substring("git-Paper-".length()).split("[-\\s]");
+-        String updateMessage = getUpdateStatusMessage("PaperMC/Paper", GITHUB_BRANCH_NAME, parts[0]);
++        String[] parts = serverVersion.substring("git-Tuinity-".length()).split("[-\\s]"); // Tuinity
++        String updateMessage = getUpdateStatusMessage("Spottedleaf/Tuinity", GITHUB_BRANCH_NAME, parts[0]); // Tuinity
+         String history = getHistory();
+ 
+         return history != null ? history + "\n" + updateMessage : updateMessage;
+@@ -50,6 +50,11 @@ public class PaperVersionFetcher implements VersionFetcher {
+     private static String getUpdateStatusMessage(@Nonnull String repo, @Nonnull String branch, @Nonnull String versionInfo) {
+         int distance;
+         try {
++            // Tuinity start
++            if (true) {
++                throw new NumberFormatException();
++            }
++            // Tuinity end
+             int jenkinsBuild = Integer.parseInt(versionInfo);
+             distance = fetchDistanceFromSiteApi(jenkinsBuild, getMinecraftVersion());
+         } catch (NumberFormatException ignored) {

--- a/patches/server/0029-Update-version-fetcher-repo.patch
+++ b/patches/server/0029-Update-version-fetcher-repo.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Update version fetcher repo
 Sets the target github repo to Tuinity in the version checker. Also disables the jenkins build lookups.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
-index 49a38c6608b652ff48ef4eaca0dd3ccb1ba570e3..79210052799b21e369f67b5932c4807a394cf08a 100644
+index 49a38c6608b652ff48ef4eaca0dd3ccb1ba570e3..255bbd6e48b95c70fad02ba692c64c7579496827 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 @@ -24,8 +24,8 @@ public class PaperVersionFetcher implements VersionFetcher {
@@ -28,11 +28,11 @@ index 49a38c6608b652ff48ef4eaca0dd3ccb1ba570e3..79210052799b21e369f67b5932c4807a
 -            int jenkinsBuild = Integer.parseInt(versionInfo);
 -            distance = fetchDistanceFromSiteApi(jenkinsBuild, getMinecraftVersion());
 -        } catch (NumberFormatException ignored) {
-+        // Tuinity start
++        // Tuinity - we don't have jenkins setup
              versionInfo = versionInfo.replace("\"", "");
              distance = fetchDistanceFromGitHub(repo, branch, versionInfo);
 -        }
-+        // Tuinity end
++        // Tuinity - we don't have jenkins setup
  
          switch (distance) {
              case -1:


### PR DESCRIPTION
Updates the paper version fetcher to use Tuinity's repo and disable's use of Paper's Parchment API.

(yes i tested it and it does work)

Fixes #45 