### PR TITLE
Add per world spawn limits

### DIFF
--- a/patches/server/0029-Per-World-Spawn-Limits.patch
+++ b/patches/server/0029-Per-World-Spawn-Limits.patch
@@ -1,0 +1,86 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Chase Whipple <chasewhip20@gmail.com>
+Date: Thu, 26 Mar 2020 21:45:54 -0600
+Subject: [PATCH] Per World Spawn Limits
+
+
+diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
+index 78c011309a26e572e176378ff80e51a035870d2c..43f8fd9ad2ab335a06c8cc45f245b71b1278db35 100644
+--- a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
++++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
+@@ -142,13 +142,13 @@ public final class TuinityConfig {
+ 
+         // we want to spread out a and b over the interval so it's smooth
+ 
+-        int aInt = (int)a;
+-        int bInt = (int)b;
++        int aInt = (int) a;
++        int bInt = (int) b;
+         double total = b;
+         maxChunkSendsPerPlayerChoice[0] = bInt;
+ 
+         for (int i = 1, len = maxChunkSendsPerPlayerChoice.length; i < len; ++i) {
+-            if (total / (double)i >= rateTick) {
++            if (total / (double) i >= rateTick) {
+                 total += a;
+                 maxChunkSendsPerPlayerChoice[i] = aInt;
+             } else {
+@@ -277,7 +277,9 @@ public final class TuinityConfig {
+             return this.config.getDouble(path, this.worldDefaults.getDouble(path));
+         }
+ 
+-        /** ignored if {@link TuinityConfig#tickWorldsInParallel} == false */
++        /**
++         * ignored if {@link TuinityConfig#tickWorldsInParallel} == false
++         */
+         public int threads;
+ 
+         /*
+@@ -287,6 +289,7 @@ public final class TuinityConfig {
+         }*/
+ 
+         public int noTickViewDistance;
++
+         private void noTickViewDistance() {
+             this.noTickViewDistance = this.getInt("no-tick-view-distance", -1);
+         }
+@@ -300,6 +303,19 @@ public final class TuinityConfig {
+             }
+             this.useOptimizedTracker = this.getBoolean("optimized-tracker", true);
+         }
+-    }
+ 
++        public int spawnLimitMonsters;
++        public int spawnLimitAnimals;
++        public int spawnLimitWaterAnimals;
++        public int spawnLimitAmbient;
++
++        private void perWorldSpawnLimit() {
++            String path = "spawn-limits";
++
++            spawnLimitMonsters = getInt(path + ".monsters", -1);
++            spawnLimitAnimals = getInt(path + ".animals", -1);
++            spawnLimitWaterAnimals = getInt(path + ".water-animals", -1);
++            spawnLimitAmbient = getInt(path + ".ambient", -1);
++        }
++    }
+ }
+\ No newline at end of file
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index 4db397d9f9b57d5281617b11c9a00743c1c947fb..680be2efeb641af65c0fa67ff1b1ba206acb302d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -329,6 +329,13 @@ public class CraftWorld implements World {
+         this.generator = gen;
+ 
+         environment = env;
++
++        //Paper start - per world spawn limits
++        monsterSpawn = world.tuinityConfig.spawnLimitMonsters;
++        animalSpawn = world.tuinityConfig.spawnLimitAnimals;
++        waterAnimalSpawn = world.tuinityConfig.spawnLimitWaterAnimals;
++        ambientSpawn = world.tuinityConfig.spawnLimitAmbient;
++        //Paper end
+     }
+ 
+     @Override

--- a/patches/server/0029-Per-World-Spawn-Limits.patch
+++ b/patches/server/0029-Per-World-Spawn-Limits.patch
@@ -31,7 +31,7 @@ index 78c011309a26e572e176378ff80e51a035870d2c..bcc5866aaee295887a323cc5cdbb08fa
  }
 \ No newline at end of file
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 4db397d9f9b57d5281617b11c9a00743c1c947fb..680be2efeb641af65c0fa67ff1b1ba206acb302d 100644
+index 4db397d9f9b57d5281617b11c9a00743c1c947fb..ae461b77b3c37f664e139ca9d1bb144235b3da91 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -329,6 +329,13 @@ public class CraftWorld implements World {
@@ -39,12 +39,12 @@ index 4db397d9f9b57d5281617b11c9a00743c1c947fb..680be2efeb641af65c0fa67ff1b1ba20
  
          environment = env;
 +
-+        //Paper start - per world spawn limits
++        //Tuinity start - per world spawn limits
 +        monsterSpawn = world.tuinityConfig.spawnLimitMonsters;
 +        animalSpawn = world.tuinityConfig.spawnLimitAnimals;
 +        waterAnimalSpawn = world.tuinityConfig.spawnLimitWaterAnimals;
 +        ambientSpawn = world.tuinityConfig.spawnLimitAmbient;
-+        //Paper end
++        //Tuinity end
      }
  
      @Override

--- a/patches/server/0029-Per-World-Spawn-Limits.patch
+++ b/patches/server/0029-Per-World-Spawn-Limits.patch
@@ -5,38 +5,10 @@ Subject: [PATCH] Per World Spawn Limits
 
 
 diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-index 78c011309a26e572e176378ff80e51a035870d2c..43f8fd9ad2ab335a06c8cc45f245b71b1278db35 100644
+index 78c011309a26e572e176378ff80e51a035870d2c..1b0cf3f059a775ba4234d35a1919aa62d20be9f8 100644
 --- a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 +++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-@@ -142,13 +142,13 @@ public final class TuinityConfig {
- 
-         // we want to spread out a and b over the interval so it's smooth
- 
--        int aInt = (int)a;
--        int bInt = (int)b;
-+        int aInt = (int) a;
-+        int bInt = (int) b;
-         double total = b;
-         maxChunkSendsPerPlayerChoice[0] = bInt;
- 
-         for (int i = 1, len = maxChunkSendsPerPlayerChoice.length; i < len; ++i) {
--            if (total / (double)i >= rateTick) {
-+            if (total / (double) i >= rateTick) {
-                 total += a;
-                 maxChunkSendsPerPlayerChoice[i] = aInt;
-             } else {
-@@ -277,7 +277,9 @@ public final class TuinityConfig {
-             return this.config.getDouble(path, this.worldDefaults.getDouble(path));
-         }
- 
--        /** ignored if {@link TuinityConfig#tickWorldsInParallel} == false */
-+        /**
-+         * ignored if {@link TuinityConfig#tickWorldsInParallel} == false
-+         */
-         public int threads;
- 
-         /*
-@@ -287,6 +289,7 @@ public final class TuinityConfig {
+@@ -287,6 +287,7 @@ public final class TuinityConfig {
          }*/
  
          public int noTickViewDistance;
@@ -44,7 +16,7 @@ index 78c011309a26e572e176378ff80e51a035870d2c..43f8fd9ad2ab335a06c8cc45f245b71b
          private void noTickViewDistance() {
              this.noTickViewDistance = this.getInt("no-tick-view-distance", -1);
          }
-@@ -300,6 +303,19 @@ public final class TuinityConfig {
+@@ -300,6 +301,19 @@ public final class TuinityConfig {
              }
              this.useOptimizedTracker = this.getBoolean("optimized-tracker", true);
          }

--- a/patches/server/0029-Per-World-Spawn-Limits.patch
+++ b/patches/server/0029-Per-World-Spawn-Limits.patch
@@ -5,18 +5,10 @@ Subject: [PATCH] Per World Spawn Limits
 
 
 diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-index 78c011309a26e572e176378ff80e51a035870d2c..1b0cf3f059a775ba4234d35a1919aa62d20be9f8 100644
+index 78c011309a26e572e176378ff80e51a035870d2c..bcc5866aaee295887a323cc5cdbb08fa66937255 100644
 --- a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 +++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-@@ -287,6 +287,7 @@ public final class TuinityConfig {
-         }*/
- 
-         public int noTickViewDistance;
-+
-         private void noTickViewDistance() {
-             this.noTickViewDistance = this.getInt("no-tick-view-distance", -1);
-         }
-@@ -300,6 +301,19 @@ public final class TuinityConfig {
+@@ -300,6 +300,19 @@ public final class TuinityConfig {
              }
              this.useOptimizedTracker = this.getBoolean("optimized-tracker", true);
          }


### PR DESCRIPTION
This adds a config option to the Tuinity config that allows configuration of spawn limits per world. This can be helpful for servers that need to nerf or increase mob spawns in the end or nether for instance with gold farms or enderman farms causing lag or being too slow. The config option was placed outside of the traditional world settings as the default was unable to be placed in the config entry as the default is in Bukkit.yml like normal.