### PR TITLE
Cleanup Github Actions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,4 +1,4 @@
-name: Pull Request builder
+name: Build PR
 
 on: [pull_request]
 
@@ -12,25 +12,30 @@ jobs:
         java: [11, 8]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.1.0
+
+    - name: Get PR info
+      run: echo ::set-env name=PR::$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v1.3.0
       with:
         java-version: ${{ matrix.java }}
+
     - uses: actions/cache@v1.1.2
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
+        restore-keys: ${{ runner.os }}-maven-
+
     - name: Patch Tuinity
       run: |
         git config --global user.email "you@example.com"
         git config --global user.name "Your Name"
         git submodule update --init --recursive
         ./tuinity jar
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v2-preview
+        
+    - uses: actions/upload-artifact@v2
       with:
-        name: Tuinity
+        name: Tuinity-PR${{ env.PR }}-JDK${{ matrix.java }}
         path: tuinity-paperclip.jar

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,4 +1,4 @@
-name: Java CI
+name: Build main
 
 on: [push]
 
@@ -12,25 +12,27 @@ jobs:
         java: [11, 8]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.1.0
+
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v1.3.0
       with:
         java-version: ${{ matrix.java }}
+
     - uses: actions/cache@v1.1.2
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
+        restore-keys: ${{ runner.os }}-maven-
+
     - name: Patch Tuinity
       run: |
         git config --global user.email "you@example.com"
         git config --global user.name "Your Name"
         git submodule update --init --recursive
         ./tuinity jar
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v2-preview
+        
+    - uses: actions/upload-artifact@v2
       with:
-        name: Tuinity
+        name: Tuinity-JDK${{ matrix.java }}
         path: tuinity-paperclip.jar


### PR DESCRIPTION
Currently a single unknown JDK artifact is produced, even though CI builds with both JDK 8 & 11. 

This PR creates an artifact for each JDK version used (ex. `Tuinity-JDK8`) as well as adding the PR number to the artifact name when building PRs (ex. `Tuinity-PR1-JDK8`). Additionally some actions were updated to latest, as well as some general cleanup.