### PR TITLE
Stripped raytracing for EntityLiving#hasLineOfSight

### DIFF
--- a/patches/server/0054-Stripped-raytracing-for-EntityLiving-hasLineOfSight.patch
+++ b/patches/server/0054-Stripped-raytracing-for-EntityLiving-hasLineOfSight.patch
@@ -1,0 +1,134 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paul Sauve <paul@burngames.net>
+Date: Sat, 17 Oct 2020 16:51:54 -0500
+Subject: [PATCH] Stripped raytracing for EntityLiving#hasLineOfSight
+
+The IBlockAccess#rayTrace method is very wasteful in both allocations,
+and in logic. While EntityLiving#hasLineOfSight provides static
+parameters for collisions with blocks and fluids, the method still does
+a lot of dynamic checks for both of these, which result in extra work.
+As well, since the fluid collision option is set to NONE, the entire
+fluid collision system is completely unneeded, yet used anyways.
+
+diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
+index 0e000c7186d9f2ed6e0a1061f83d7f2d5695dc37..747998f811b4da9119fb7de02e1441a21cf91694 100644
+--- a/src/main/java/net/minecraft/server/EntityLiving.java
++++ b/src/main/java/net/minecraft/server/EntityLiving.java
+@@ -2975,7 +2975,7 @@ public abstract class EntityLiving extends Entity {
+         Vec3D vec3d = new Vec3D(this.locX(), this.getHeadY(), this.locZ());
+         Vec3D vec3d1 = new Vec3D(entity.locX(), entity.getHeadY(), entity.locZ());
+ 
+-        return this.world.rayTrace(new RayTrace(vec3d, vec3d1, RayTrace.BlockCollisionOption.COLLIDER, RayTrace.FluidCollisionOption.NONE, this)).getType() == MovingObjectPosition.EnumMovingObjectType.MISS;
++        return this.world.rayTraceDirect(vec3d, vec3d1, VoxelShapeCollision.a(this)) == MovingObjectPosition.EnumMovingObjectType.MISS; // Tuinity - use direct method
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/IBlockAccess.java b/src/main/java/net/minecraft/server/IBlockAccess.java
+index b90c9990668f7956e8ef67413bcfc5d7d9616db1..391aebdad9f5e41212f781244ea896ad80c84ec9 100644
+--- a/src/main/java/net/minecraft/server/IBlockAccess.java
++++ b/src/main/java/net/minecraft/server/IBlockAccess.java
+@@ -44,6 +44,16 @@ public interface IBlockAccess {
+         return BlockPosition.a(axisalignedbb).map(this::getType);
+     }
+ 
++    // Tuinity start - broken down variant of below rayTraceBlock, used by World#rayTraceDirect
++    default MovingObjectPosition.EnumMovingObjectType rayTraceBlockDirect(Vec3D vec3d, Vec3D vec3d1, BlockPosition blockposition, IBlockData iblockdata, VoxelShapeCollision voxelshapecoll) {
++        RayTrace.BlockCollisionOption raytrace_blockcollisionoption = RayTrace.BlockCollisionOption.COLLIDER;
++        VoxelShape voxelshape = raytrace_blockcollisionoption.get(iblockdata, this, blockposition, voxelshapecoll); // Collider doesn't actually need a voxelshape
++        MovingObjectPositionBlock movingobjectpositionblock = this.rayTrace(vec3d, vec3d1, blockposition, voxelshape, iblockdata);
++
++        return movingobjectpositionblock == null ? null : movingobjectpositionblock.getType(); // can't be null because of the logic above
++    }
++    // Tuinity end
++
+     // CraftBukkit start - moved block handling into separate method for use by Block#rayTrace
+     default MovingObjectPositionBlock rayTraceBlock(RayTrace raytrace1, BlockPosition blockposition) {
+             // Paper start - Prevent raytrace from loading chunks
+diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
+index 51cb07b3d5c2d271e3a17e99ea08428c26d59de1..54f42c0fca6480de7b3aff41ed80b4f5851e255e 100644
+--- a/src/main/java/net/minecraft/server/World.java
++++ b/src/main/java/net/minecraft/server/World.java
+@@ -259,6 +259,83 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+         return null;
+     }
+ 
++    // Tuinity start - broken down method of raytracing for EntityLiving#hasLineOfSight, replaces IBlockAccess#rayTrace(RayTrace)
++    protected MovingObjectPosition.EnumMovingObjectType rayTraceDirect(Vec3D vec3d, Vec3D vec3d1, VoxelShapeCollision voxelshapecoll) {
++        // most of this code comes from IBlockAccess#a(RayTrace, BiFunction, Function), but removes the needless functions
++        if (vec3d.equals(vec3d1)) {
++            return MovingObjectPosition.EnumMovingObjectType.MISS;
++        }
++        double d0 = MathHelper.d(-1.0E-7D, vec3d1.x, vec3d.x);
++        double d1 = MathHelper.d(-1.0E-7D, vec3d1.y, vec3d.y);
++        double d2 = MathHelper.d(-1.0E-7D, vec3d1.z, vec3d.z);
++        double d3 = MathHelper.d(-1.0E-7D, vec3d.x, vec3d1.x);
++        double d4 = MathHelper.d(-1.0E-7D, vec3d.y, vec3d1.y);
++        double d5 = MathHelper.d(-1.0E-7D, vec3d.z, vec3d1.z);
++        int i = MathHelper.floor(d3);
++        int j = MathHelper.floor(d4);
++        int k = MathHelper.floor(d5);
++        BlockPosition.MutableBlockPosition blockposition_mutableblockposition = new BlockPosition.MutableBlockPosition(i, j, k);
++        Chunk chunk = this.getChunkIfLoaded(blockposition_mutableblockposition);
++        if (chunk == null) {
++            return MovingObjectPosition.EnumMovingObjectType.MISS;
++        }
++
++        MovingObjectPosition.EnumMovingObjectType t0 = this.rayTraceBlockDirect(vec3d, vec3d1, blockposition_mutableblockposition, chunk.getType(blockposition_mutableblockposition), voxelshapecoll);
++
++        if (t0 != null) {
++            return t0;
++        } else {
++            double d6 = d0 - d3;
++            double d7 = d1 - d4;
++            double d8 = d2 - d5;
++            int l = MathHelper.k(d6);
++            int i1 = MathHelper.k(d7);
++            int j1 = MathHelper.k(d8);
++            double d9 = l == 0 ? Double.MAX_VALUE : (double) l / d6;
++            double d10 = i1 == 0 ? Double.MAX_VALUE : (double) i1 / d7;
++            double d11 = j1 == 0 ? Double.MAX_VALUE : (double) j1 / d8;
++            double d12 = d9 * (l > 0 ? 1.0D - MathHelper.h(d3) : MathHelper.h(d3));
++            double d13 = d10 * (i1 > 0 ? 1.0D - MathHelper.h(d4) : MathHelper.h(d4));
++            double d14 = d11 * (j1 > 0 ? 1.0D - MathHelper.h(d5) : MathHelper.h(d5));
++
++            MovingObjectPosition.EnumMovingObjectType object;
++
++            do {
++                if (d12 > 1.0D && d13 > 1.0D && d14 > 1.0D) {
++                    return MovingObjectPosition.EnumMovingObjectType.MISS;
++                }
++
++                if (d12 < d13) {
++                    if (d12 < d14) {
++                        i += l;
++                        d12 += d9;
++                    } else {
++                        k += j1;
++                        d14 += d11;
++                    }
++                } else if (d13 < d14) {
++                    j += i1;
++                    d13 += d10;
++                } else {
++                    k += j1;
++                    d14 += d11;
++                }
++
++                blockposition_mutableblockposition.d(i, j, k);
++                if (chunk.getPos().x != blockposition_mutableblockposition.getX() >> 4 || chunk.getPos().z != blockposition_mutableblockposition.getZ() >> 4) {
++                    chunk = this.getChunkIfLoaded(blockposition_mutableblockposition);
++                    if (chunk == null) {
++                        return MovingObjectPosition.EnumMovingObjectType.MISS;
++                    }
++                }
++                object = this.rayTraceBlockDirect(vec3d, vec3d1, blockposition_mutableblockposition, chunk.getType(blockposition_mutableblockposition), voxelshapecoll);
++            } while (object == null);
++
++            return object;
++        }
++    }
++    // Tuinity end
++
+     public static boolean isValidLocation(BlockPosition blockposition) {
+         return blockposition.isValidLocation(); // Paper - use better/optimized check
+     }


### PR DESCRIPTION
The IBlockAccess#rayTrace method is very wasteful in both allocations, and in logic. While EntityLiving#hasLineOfSight provides static parameters for collisions with blocks and fluids, the method still does a lot of dynamic checks for both of these, which result in extra work. As well, since the fluid collision option is set to NONE, the entire fluid collision system is completely unneeded, yet used anyways.