### PR TITLE
Fix Github Actions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -12,17 +12,17 @@ jobs:
         java: [11, 8]
 
     steps:
-    - uses: actions/checkout@v2.3.3
+    - uses: actions/checkout@v2
 
     - name: Get PR info
       run: echo ::set-env name=PR::$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
 
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
 
-    - uses: actions/cache@v2.1.2
+    - uses: actions/cache@v2
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -12,17 +12,17 @@ jobs:
         java: [11, 8]
 
     steps:
-    - uses: actions/checkout@v2.1.0
+    - uses: actions/checkout@v2.3.3
 
     - name: Get PR info
       run: echo ::set-env name=PR::$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
 
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1.3.0
+      uses: actions/setup-java@v1.4.3
       with:
         java-version: ${{ matrix.java }}
 
-    - uses: actions/cache@v1.1.2
+    - uses: actions/cache@v2.1.2
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,14 +12,14 @@ jobs:
         java: [11, 8]
 
     steps:
-    - uses: actions/checkout@v2.3.3
+    - uses: actions/checkout@v2
 
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
 
-    - uses: actions/cache@v2.1.2
+    - uses: actions/cache@v2
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,14 +12,14 @@ jobs:
         java: [11, 8]
 
     steps:
-    - uses: actions/checkout@v2.1.0
+    - uses: actions/checkout@v2.3.3
 
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1.3.0
+      uses: actions/setup-java@v1.4.3
       with:
         java-version: ${{ matrix.java }}
 
-    - uses: actions/cache@v1.1.2
+    - uses: actions/cache@v2.1.2
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
On the actions page, on any new action recently run, there is this message `The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/`. I have fixed this by updating most of the actions used :)