### PR TITLE
Updated Upstream (Paper)

### DIFF
--- a/patches/server/0004-Util-patch.patch
+++ b/patches/server/0004-Util-patch.patch
@@ -882,10 +882,10 @@ index 1f334d63282bd5c23dc3b275a220f09e60c34537..85f60b56b5689b77ba3d9e99e29b4f73
  
          public final boolean e() { // Paper
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 6acb5f05a05c542f8257e205ef70987be2d29194..b1a166365053c4096f082d8a53de05d38bde8159 100644
+index 75d25576d68ec95a14372f8530f4916f2bd7c3c5..5e2168fa0958325358a9c41478d70c78accb53d1 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-@@ -121,7 +121,7 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -112,7 +112,7 @@ public class ChunkProviderServer extends IChunkProvider {
          return (Chunk)this.getChunkAt(x, z, ChunkStatus.FULL, true);
      }
  
@@ -894,7 +894,7 @@ index 6acb5f05a05c542f8257e205ef70987be2d29194..b1a166365053c4096f082d8a53de05d3
  
      public void getEntityTickingChunkAsync(int x, int z, java.util.function.Consumer<Chunk> onLoad) {
          if (Thread.currentThread() != this.serverThread) {
-@@ -210,6 +210,165 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -201,6 +201,165 @@ public class ChunkProviderServer extends IChunkProvider {
      }
      // Paper end - rewrite ticklistserver
  
@@ -1060,7 +1060,7 @@ index 6acb5f05a05c542f8257e205ef70987be2d29194..b1a166365053c4096f082d8a53de05d3
      public ChunkProviderServer(WorldServer worldserver, Convertable.ConversionSession convertable_conversionsession, DataFixer datafixer, DefinedStructureManager definedstructuremanager, Executor executor, ChunkGenerator chunkgenerator, int i, boolean flag, WorldLoadListener worldloadlistener, Supplier<WorldPersistentData> supplier) {
          this.world = worldserver;
          this.serverThreadQueue = new ChunkProviderServer.a(worldserver);
-@@ -600,8 +759,8 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -591,8 +750,8 @@ public class ChunkProviderServer extends IChunkProvider {
          return !this.a(playerchunk, k);
      }
  
@@ -1072,7 +1072,7 @@ index 6acb5f05a05c542f8257e205ef70987be2d29194..b1a166365053c4096f082d8a53de05d3
          PlayerChunk playerchunk = this.getChunk(k);
  
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index d9021fde3d0908dc89384617055874ac356a8fcf..4fc96ef8c6062d94fb58aa274e9050235dcb1b9b 100644
+index 36fbe16e6f06fca3eb282cce5b8c5fcc87a0166d..4ca947fddfbe4e4e3d48c95d6ebd655cb4ee3df2 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -207,6 +207,14 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -1277,7 +1277,7 @@ index e21c747b6c39155c44bf30860681d67b0b29fb12..9f4f9df09968dc45878ad59f5ee45672
          return voxelshape != b() && voxelshape1 != b() ? (voxelshape.isEmpty() && voxelshape1.isEmpty() ? false : !c(b(), b(voxelshape, voxelshape1, OperatorBoolean.OR), OperatorBoolean.ONLY_FIRST)) : true;
      }
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index b033ff44373ec87702946c3cefe664fb46d609f4..e2c069c84f8f0039770ff756446e2c9246221166 100644
+index 9c50357bb5da309b7cad74fdee15697a20e2e15f..7ff860437f01c64b08812c5ae01e47a5cda113de 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -55,6 +55,7 @@ import org.bukkit.event.server.MapInitializeEvent;

--- a/patches/server/0005-Tuinity-Server-Config.patch
+++ b/patches/server/0005-Tuinity-Server-Config.patch
@@ -286,7 +286,7 @@ index 5f0c779db75f50e00a16909248f5fe5abc42b784..31ed7dd946b24a340daa9d546892ccfc
                  org.spigotmc.WatchdogThread.hasStarted = true; // Paper
                  Arrays.fill( recentTps, 20 );
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 277c051f814d25dd7c57cdba268ea044873c88d5..3f842f457a43a3c36ab62c344c80351f61067e73 100644
+index 02303f00e243748b9d1c4a37719fcf5c8d271ed9..38c49d04d7bfb9c116a3b6eb87daaad2c75040cf 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -94,6 +94,8 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/patches/server/0008-Add-soft-async-catcher.patch
+++ b/patches/server/0008-Add-soft-async-catcher.patch
@@ -148,10 +148,10 @@ index 033548a58d27f64d3954206d267783c0437d4019..08ed243259f052165c6f75aed1d1d65a
  
      public TickThread(final Runnable run, final String name, final int id) {
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 9c078d30afef20bd1ea5975299c5513334829b19..5d106d3330b27eb060bc36773651f51604276829 100644
+index af9d54ef057d5f6977cf77c57cde25b6b0d1f39d..8816d3326af25431e2235c5e735e86c7335f60dc 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
-@@ -547,6 +547,7 @@ public class Chunk implements IChunkAccess {
+@@ -548,6 +548,7 @@ public class Chunk implements IChunkAccess {
  
      @Override
      public void a(Entity entity) {
@@ -159,7 +159,7 @@ index 9c078d30afef20bd1ea5975299c5513334829b19..5d106d3330b27eb060bc36773651f516
          this.q = true;
          int i = MathHelper.floor(entity.locX() / 16.0D);
          int j = MathHelper.floor(entity.locZ() / 16.0D);
-@@ -616,6 +617,7 @@ public class Chunk implements IChunkAccess {
+@@ -617,6 +618,7 @@ public class Chunk implements IChunkAccess {
      }
  
      public void a(Entity entity, int i) {
@@ -220,10 +220,10 @@ index 3c7b225edbe23dc1959002293a6f8b816287b5a8..d3588e238506ea859407b72da0d0cf29
  
          for (java.util.Iterator<Entry<ArraySetSorted<Ticket<?>>>> iterator = this.tickets.long2ObjectEntrySet().fastIterator(); iterator.hasNext();) {
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index b1a166365053c4096f082d8a53de05d38bde8159..8dc0dd527daf5141f648bda8735b06e672ab9a22 100644
+index 5e2168fa0958325358a9c41478d70c78accb53d1..d68f91a881e001649f20e9257a4b2a4a8fc2cb04 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-@@ -1199,6 +1199,7 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -1190,6 +1190,7 @@ public class ChunkProviderServer extends IChunkProvider {
  
          @Override
          protected boolean executeNext() {
@@ -304,7 +304,7 @@ index fb46fdeb22a7c31c8d132bdc80d657ae82c191be..2be8c1b7974f3f6271be60872d45123b
  
          this.noTickViewDistance = viewDistance;
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 3f842f457a43a3c36ab62c344c80351f61067e73..2ec682d91dc1cc0f7e5a51c7adad3ae14e3551f1 100644
+index 38c49d04d7bfb9c116a3b6eb87daaad2c75040cf..ab8a5c00e383ef84cb3e5acf9ac9221f672effdd 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -363,6 +363,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
@@ -315,7 +315,7 @@ index 3f842f457a43a3c36ab62c344c80351f61067e73..2ec682d91dc1cc0f7e5a51c7adad3ae1
          // CraftBukkit start - tree generation
          if (this.captureTreeGeneration) {
              // Paper start
-@@ -463,6 +464,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -464,6 +465,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
  
      // CraftBukkit start - Split off from above in order to directly send client and physic updates
      public void notifyAndUpdatePhysics(BlockPosition blockposition, Chunk chunk, IBlockData oldBlock, IBlockData newBlock, IBlockData actualBlock, int i, int j) {
@@ -324,7 +324,7 @@ index 3f842f457a43a3c36ab62c344c80351f61067e73..2ec682d91dc1cc0f7e5a51c7adad3ae1
          IBlockData iblockdata1 = oldBlock;
          IBlockData iblockdata2 = actualBlock;
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index e2c069c84f8f0039770ff756446e2c9246221166..f2d9c050cf962c61c8641472073283a893ef9894 100644
+index 7ff860437f01c64b08812c5ae01e47a5cda113de..50ee5a1cdf91d9a2e720e5772c20cfd2e5064683 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -1660,6 +1660,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/patches/server/0014-Detail-more-information-in-watchdog-dumps.patch
+++ b/patches/server/0014-Detail-more-information-in-watchdog-dumps.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Detail more information in watchdog dumps
 - Dump player name, player uuid, position, and world for packet handling
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 4fc96ef8c6062d94fb58aa274e9050235dcb1b9b..56db744999c1b3938b7db0a4fc3c924446dbd2c9 100644
+index 4ca947fddfbe4e4e3d48c95d6ebd655cb4ee3df2..cc8c7a2533d45be1b3441e03b2130436dcc45393 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -599,7 +599,39 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -64,7 +64,7 @@ index 4fc96ef8c6062d94fb58aa274e9050235dcb1b9b..56db744999c1b3938b7db0a4fc3c9244
      }
  
      protected BlockPosition ap() {
-@@ -3309,12 +3348,16 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -3315,12 +3354,16 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
          return this.locBlock;
      }
  
@@ -81,7 +81,7 @@ index 4fc96ef8c6062d94fb58aa274e9050235dcb1b9b..56db744999c1b3938b7db0a4fc3c9244
      }
  
      public void setMot(double d0, double d1, double d2) {
-@@ -3369,7 +3412,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -3375,7 +3418,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
          }
          // Paper end
          if (this.loc.x != d0 || this.loc.y != d1 || this.loc.z != d2) {
@@ -140,7 +140,7 @@ index 7ea293f38dedd6066601d94adbe175a31c502e1f..e698dd22607b2b2c4068c5bfb03ac53e
              });
              throw CancelledPacketHandleException.INSTANCE;
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index f2d9c050cf962c61c8641472073283a893ef9894..f6e07d5f2432756d6ce687162dae87990fc6e8a2 100644
+index 50ee5a1cdf91d9a2e720e5772c20cfd2e5064683..3e2299839217ac468d7cb4361fae972f400c8eaa 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -900,7 +900,26 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/patches/server/0015-Execute-chunk-tasks-mid-tick.patch
+++ b/patches/server/0015-Execute-chunk-tasks-mid-tick.patch
@@ -18,10 +18,10 @@ index a263cd7a0680e0cc3517f84308118eb32c487732..77df6888803093ad9527d276033f2ed7
                      // re-schedule eventually
                      toTick.tickState = STATE_SCHEDULED;
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 8dc0dd527daf5141f648bda8735b06e672ab9a22..130872258e5d2814a84e927c30fec5c06c544ca1 100644
+index d68f91a881e001649f20e9257a4b2a4a8fc2cb04..2a28502f9e2bc812370d0258d1c1d492b061b464 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-@@ -894,7 +894,7 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -885,7 +885,7 @@ public class ChunkProviderServer extends IChunkProvider {
          this.world.getMethodProfiler().enter("purge");
          this.world.timings.doChunkMap.startTiming(); // Spigot
          this.chunkMapDistance.purgeTickets();
@@ -30,7 +30,7 @@ index 8dc0dd527daf5141f648bda8735b06e672ab9a22..130872258e5d2814a84e927c30fec5c0
          this.tickDistanceManager();
          this.world.timings.doChunkMap.stopTiming(); // Spigot
          this.world.getMethodProfiler().exitEnter("chunks");
-@@ -904,7 +904,7 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -895,7 +895,7 @@ public class ChunkProviderServer extends IChunkProvider {
          this.world.timings.doChunkUnload.startTiming(); // Spigot
          this.world.getMethodProfiler().exitEnter("unload");
          this.playerChunkMap.unloadChunks(booleansupplier);
@@ -39,7 +39,7 @@ index 8dc0dd527daf5141f648bda8735b06e672ab9a22..130872258e5d2814a84e927c30fec5c0
          this.world.timings.doChunkUnload.stopTiming(); // Spigot
          this.world.getMethodProfiler().exit();
          this.clearCache();
-@@ -1005,7 +1005,7 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -996,7 +996,7 @@ public class ChunkProviderServer extends IChunkProvider {
                              this.world.timings.chunkTicks.startTiming(); // Spigot // Paper
                              this.world.a(chunk, k);
                              this.world.timings.chunkTicks.stopTiming(); // Spigot // Paper
@@ -48,7 +48,7 @@ index 8dc0dd527daf5141f648bda8735b06e672ab9a22..130872258e5d2814a84e927c30fec5c0
                          }
                      }
                  }
-@@ -1161,41 +1161,7 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -1152,41 +1152,7 @@ public class ChunkProviderServer extends IChunkProvider {
              ChunkProviderServer.this.world.getMethodProfiler().c("runTask");
              super.executeTask(runnable);
          }
@@ -267,10 +267,10 @@ index 31ed7dd946b24a340daa9d546892ccfc2c8bb0b0..6af51b7bfeff0d1cee1e1e5fe9901cc3
                  // Spigot Start
                  CrashReport crashreport;
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 2ec682d91dc1cc0f7e5a51c7adad3ae14e3551f1..ba749d70f4b5709b2abf4ebbc60d574fc33db198 100644
+index ab8a5c00e383ef84cb3e5acf9ac9221f672effdd..e3ed8fb7881bc00b1b2345c1682f30057878d41a 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -900,6 +900,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -901,6 +901,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
              return;
              // Paper end
          }
@@ -279,7 +279,7 @@ index 2ec682d91dc1cc0f7e5a51c7adad3ae14e3551f1..ba749d70f4b5709b2abf4ebbc60d574f
      // Paper start - Prevent armor stands from doing entity lookups
      @Override
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index f6e07d5f2432756d6ce687162dae87990fc6e8a2..76e48d8d6f037c034e6cfe80d6022fdbed862000 100644
+index 3e2299839217ac468d7cb4361fae972f400c8eaa..d9c460bc56f8e7fafb1bea621336f09a56a6cc00 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -296,6 +296,10 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/patches/server/0018-Consolidate-flush-calls-for-entity-tracker-packets.patch
+++ b/patches/server/0018-Consolidate-flush-calls-for-entity-tracker-packets.patch
@@ -22,10 +22,10 @@ With this change I could get all 200 on at 0ms ping.
 So in general this patch should reduce Netty I/O thread load.
 
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 130872258e5d2814a84e927c30fec5c06c544ca1..878aac8a9788da4dbfe897d412bdec411020d77d 100644
+index 2a28502f9e2bc812370d0258d1c1d492b061b464..89abe51205c7c03fdb3937d10c95d15228401b0c 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-@@ -1021,7 +1021,25 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -1012,7 +1012,25 @@ public class ChunkProviderServer extends IChunkProvider {
              this.world.getMethodProfiler().exit();
          }
  

--- a/patches/server/0020-Make-CallbackExecutor-strict-again.patch
+++ b/patches/server/0020-Make-CallbackExecutor-strict-again.patch
@@ -19,10 +19,10 @@ This patch also reverts incorrect use(s) of the class by paper.
   any exception thrown from it.
 
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 878aac8a9788da4dbfe897d412bdec411020d77d..cf065427799e6e69037377b16cf4c52bc5073931 100644
+index 89abe51205c7c03fdb3937d10c95d15228401b0c..26db7d4f9c5e9bb5ecd7f79e263d365d98f70fd7 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-@@ -183,9 +183,9 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -174,9 +174,9 @@ public class ChunkProviderServer extends IChunkProvider {
  
                  try {
                      if (onLoad != null) {

--- a/patches/server/0021-Optimise-entity-hard-collision-checking.patch
+++ b/patches/server/0021-Optimise-entity-hard-collision-checking.patch
@@ -11,7 +11,7 @@ Less crammed entities are likely to show significantly less benefit.
 Effectively, this patch optimises crammed entity situations.
 
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 5d106d3330b27eb060bc36773651f51604276829..394765e2a0766002ea32ca816c0d95356d1caffb 100644
+index 8816d3326af25431e2235c5e735e86c7335f60dc..2e25102b6d7e71b0a536e77c2116981aed8623e2 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -91,6 +91,56 @@ public class Chunk implements IChunkAccess {
@@ -71,7 +71,7 @@ index 5d106d3330b27eb060bc36773651f51604276829..394765e2a0766002ea32ca816c0d9535
      public Chunk(World world, ChunkCoordIntPair chunkcoordintpair, BiomeStorage biomestorage, ChunkConverter chunkconverter, TickList<Block> ticklist, TickList<FluidType> ticklist1, long i, @Nullable ChunkSection[] achunksection, @Nullable Consumer<Chunk> consumer) {
          this.sections = new ChunkSection[16];
          this.e = Maps.newHashMap();
-@@ -594,7 +644,7 @@ public class Chunk implements IChunkAccess {
+@@ -595,7 +645,7 @@ public class Chunk implements IChunkAccess {
          entity.chunkY = k;
          entity.chunkZ = this.loc.z;
          this.entities.add(entity); // Paper - per chunk entity list
@@ -80,7 +80,7 @@ index 5d106d3330b27eb060bc36773651f51604276829..394765e2a0766002ea32ca816c0d9535
          // Paper start
          if (entity instanceof EntityItem) {
              itemCounts[k]++;
-@@ -632,7 +682,7 @@ public class Chunk implements IChunkAccess {
+@@ -633,7 +683,7 @@ public class Chunk implements IChunkAccess {
              entity.entitySlice = null;
              entity.inChunk = false;
          }
@@ -90,7 +90,7 @@ index 5d106d3330b27eb060bc36773651f51604276829..394765e2a0766002ea32ca816c0d9535
          }
          if (entity instanceof EntityItem) {
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 56db744999c1b3938b7db0a4fc3c924446dbd2c9..82099329cfb47abc7aef60a672ca28e48ecf507d 100644
+index cc8c7a2533d45be1b3441e03b2130436dcc45393..0636139860a715a2071fe704fbc216c66e246112 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -230,6 +230,41 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -191,10 +191,10 @@ index 2639c17b7f6100533f33124f9e49990cd303d161..b053bb74f6df174a27dbfd7b1b3e3ccb
      }
  
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index ba749d70f4b5709b2abf4ebbc60d574fc33db198..7c7170531578858724cad5905e47cd84401e288e 100644
+index e3ed8fb7881bc00b1b2345c1682f30057878d41a..8ec6b3a1b8f5281b875cbb3cf85833ab3c208bc3 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -1084,6 +1084,35 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -1085,6 +1085,35 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
          return this.getChunkAt(i, j, ChunkStatus.FULL, false);
      }
  

--- a/patches/server/0025-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
+++ b/patches/server/0025-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
@@ -599,7 +599,7 @@ index 95ef96286855624590b72d69514b0fc0e08fddba..73163b417af7e522a4509bf9c1ab56d6
          T t0 = this.h.a(this.a.a(i));
  
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 82099329cfb47abc7aef60a672ca28e48ecf507d..d6a4065424932cd66d995f12560d0d13d56c1493 100644
+index 0636139860a715a2071fe704fbc216c66e246112..65075ec384f839fa47e93458a942376f59472d6e 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -136,7 +136,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -1238,10 +1238,10 @@ index 9f4f9df09968dc45878ad59f5ee45672a3f08fbd..db735e29d427cc8f4bd4ba54c7a44daf
  
      @VisibleForTesting
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 7c7170531578858724cad5905e47cd84401e288e..f3bb6aaa916d11b9326b556b772ef9699fb4c1e2 100644
+index 8ec6b3a1b8f5281b875cbb3cf85833ab3c208bc3..9d9ff42a4572da8f62cc9fc5f11053b578858767 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -1115,8 +1115,13 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -1116,8 +1116,13 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
  
      @Override
      public List<Entity> getEntities(@Nullable Entity entity, AxisAlignedBB axisalignedbb, @Nullable Predicate<? super Entity> predicate) {
@@ -1344,7 +1344,7 @@ index f011869880fedae4b69e505491e8bdbc5f51dfba..0d10d317cd0b60fc0866ae505c7fd71f
          return this.j.d();
      }
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 76e48d8d6f037c034e6cfe80d6022fdbed862000..3e314d715a53582581096deb4b8b97f7a8bf8de9 100644
+index d9c460bc56f8e7fafb1bea621336f09a56a6cc00..ec8c1624fc90897257ae808359582f0c2f7c3c71 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -360,6 +360,451 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/patches/server/0027-Optimise-chunk-tick-iteration.patch
+++ b/patches/server/0027-Optimise-chunk-tick-iteration.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Optimise chunk tick iteration
 Use a dedicated list of entity ticking chunks to reduce the cost
 
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index cf065427799e6e69037377b16cf4c52bc5073931..c81ca690351729d0e5a9002b49bfcd50ead2caba 100644
+index 26db7d4f9c5e9bb5ecd7f79e263d365d98f70fd7..b7dd5cebab80bdd444a1e464e2092b345e54064a 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -22,6 +22,12 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap; // Paper
@@ -22,7 +22,7 @@ index cf065427799e6e69037377b16cf4c52bc5073931..c81ca690351729d0e5a9002b49bfcd50
  public class ChunkProviderServer extends IChunkProvider {
  
      private static final List<ChunkStatus> b = ChunkStatus.a(); static final List<ChunkStatus> getPossibleChunkStatuses() { return ChunkProviderServer.b; } // Paper - OBFHELPER
-@@ -981,19 +987,23 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -972,19 +978,23 @@ public class ChunkProviderServer extends IChunkProvider {
              //List<PlayerChunk> list = Lists.newArrayList(this.playerChunkMap.f()); // Paper
              //Collections.shuffle(list); // Paper
              // Paper - moved up
@@ -54,7 +54,7 @@ index cf065427799e6e69037377b16cf4c52bc5073931..c81ca690351729d0e5a9002b49bfcd50
                          ChunkCoordIntPair chunkcoordintpair = playerchunk.i();
  
                          if (!this.playerChunkMap.isOutsideOfRange(playerchunk, chunkcoordintpair, false)) { // Paper - optimise isOutsideOfRange
-@@ -1009,7 +1019,11 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -1000,7 +1010,11 @@ public class ChunkProviderServer extends IChunkProvider {
                          }
                      }
                  }

--- a/patches/server/0033-Allow-Entities-to-be-removed-from-a-world-while-tick.patch
+++ b/patches/server/0033-Allow-Entities-to-be-removed-from-a-world-while-tick.patch
@@ -9,7 +9,7 @@ issues where teleporting players across worlds while ticking.
 Also allows us to run mid tick while ticking entities.
 
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 3e314d715a53582581096deb4b8b97f7a8bf8de9..271e456648ef428404291cf43e6989a7f3ee7f0b 100644
+index ec8c1624fc90897257ae808359582f0c2f7c3c71..9ec624ed52be2a6f6d06fbf1b7f928bb5fa4304e 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -61,7 +61,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/patches/server/0034-Prevent-unload-calls-removing-tickets-for-sync-loads.patch
+++ b/patches/server/0034-Prevent-unload-calls-removing-tickets-for-sync-loads.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent unload() calls removing tickets for sync loads
 
 
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index c81ca690351729d0e5a9002b49bfcd50ead2caba..474ce4ef7556aa79c75fa3867a5f1d3b3bae67c8 100644
+index b7dd5cebab80bdd444a1e464e2092b345e54064a..65047884a1b5edeef5777e329aa0a1b3f11e293e 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-@@ -710,6 +710,8 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -701,6 +701,8 @@ public class ChunkProviderServer extends IChunkProvider {
          Arrays.fill(this.cacheChunk, (Object) null);
      }
  
@@ -17,7 +17,7 @@ index c81ca690351729d0e5a9002b49bfcd50ead2caba..474ce4ef7556aa79c75fa3867a5f1d3b
      private CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> getChunkFutureMainThread(int i, int j, ChunkStatus chunkstatus, boolean flag) {
          // Paper start - add isUrgent - old sig left in place for dirty nms plugins
          return getChunkFutureMainThread(i, j, chunkstatus, flag, false);
-@@ -728,9 +730,12 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -719,9 +721,12 @@ public class ChunkProviderServer extends IChunkProvider {
              PlayerChunk.State currentChunkState = PlayerChunk.getChunkState(playerchunk.getTicketLevel());
              currentlyUnloading = (oldChunkState.isAtLeast(PlayerChunk.State.BORDER) && !currentChunkState.isAtLeast(PlayerChunk.State.BORDER));
          }
@@ -30,7 +30,7 @@ index c81ca690351729d0e5a9002b49bfcd50ead2caba..474ce4ef7556aa79c75fa3867a5f1d3b
              if (isUrgent) this.chunkMapDistance.markUrgent(chunkcoordintpair); // Paper
              if (this.a(playerchunk, l)) {
                  GameProfilerFiller gameprofilerfiller = this.world.getMethodProfiler();
-@@ -741,12 +746,20 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -732,12 +737,20 @@ public class ChunkProviderServer extends IChunkProvider {
                  playerchunk = this.getChunk(k);
                  gameprofilerfiller.exit();
                  if (this.a(playerchunk, l)) {

--- a/patches/server/0039-Distance-manager-tick-timings.patch
+++ b/patches/server/0039-Distance-manager-tick-timings.patch
@@ -19,10 +19,10 @@ index 7991c66a8fe7ee9725ab75fb80d1363cd7348532..68ab5ccb2fcfe1de0503c9336572f28e
      private static final Map<Class<?>, String> taskNameCache = new MapMaker().weakKeys().makeMap();
  
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 474ce4ef7556aa79c75fa3867a5f1d3b3bae67c8..dc0d578fcfef055d816f1ae7fdbacd42b5fb5e30 100644
+index 65047884a1b5edeef5777e329aa0a1b3f11e293e..c8806d4cb24e32abdb2f800ddc36ac78c4a0328a 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-@@ -816,6 +816,7 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -807,6 +807,7 @@ public class ChunkProviderServer extends IChunkProvider {
  
      public boolean tickDistanceManager() { // Paper - private -> public
          if (chunkMapDistance.delayDistanceManagerTick) return false; // Paper
@@ -30,7 +30,7 @@ index 474ce4ef7556aa79c75fa3867a5f1d3b3bae67c8..dc0d578fcfef055d816f1ae7fdbacd42
          boolean flag = this.chunkMapDistance.a(this.playerChunkMap);
          boolean flag1 = this.playerChunkMap.b();
  
-@@ -825,6 +826,7 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -816,6 +817,7 @@ public class ChunkProviderServer extends IChunkProvider {
              this.clearCache();
              return true;
          }

--- a/patches/server/0044-Do-not-allow-ticket-level-changes-while-unloading-pl.patch
+++ b/patches/server/0044-Do-not-allow-ticket-level-changes-while-unloading-pl.patch
@@ -8,10 +8,10 @@ Sync loading the chunk at this stage would cause it to load
 older data, as well as screwing our region state.
 
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index dc0d578fcfef055d816f1ae7fdbacd42b5fb5e30..84429f12d0c6e0990b7cbb1b503b7868b3a02b14 100644
+index c8806d4cb24e32abdb2f800ddc36ac78c4a0328a..a44fbfaf42170e57729ecbc23e034d8745d45785 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-@@ -816,6 +816,7 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -807,6 +807,7 @@ public class ChunkProviderServer extends IChunkProvider {
  
      public boolean tickDistanceManager() { // Paper - private -> public
          if (chunkMapDistance.delayDistanceManagerTick) return false; // Paper

--- a/patches/server/0045-Make-sure-inlined-getChunkAt-has-inlined-logic-for-l.patch
+++ b/patches/server/0045-Make-sure-inlined-getChunkAt-has-inlined-logic-for-l.patch
@@ -13,7 +13,7 @@ Paper recently reverted this optimisation, so it's been reintroduced
 here.
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index f3bb6aaa916d11b9326b556b772ef9699fb4c1e2..5bfc4db788bf63272211491a100ca5c69d77de44 100644
+index 9d9ff42a4572da8f62cc9fc5f11053b578858767..6c3f496ba6c0c6c4911e2592ded27df08ae54b14 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -289,6 +289,15 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/patches/server/0048-Optimise-closest-entity-lookup-used-by-AI-goals.patch
+++ b/patches/server/0048-Optimise-closest-entity-lookup-used-by-AI-goals.patch
@@ -240,7 +240,7 @@ index 387eeb5d770ba9fe564c61df8cc92ac8b1569f61..21e50c75e0bffaa5cc5faf6aa81ae742
      }
  }
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 394765e2a0766002ea32ca816c0d95356d1caffb..cebce2a4029263ba0caf529196482c41009beb1c 100644
+index 2e25102b6d7e71b0a536e77c2116981aed8623e2..8c6c653b3454f59cf823fd92f7b464a8f998b675 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -141,6 +141,22 @@ public class Chunk implements IChunkAccess {
@@ -266,7 +266,7 @@ index 394765e2a0766002ea32ca816c0d95356d1caffb..cebce2a4029263ba0caf529196482c41
      public Chunk(World world, ChunkCoordIntPair chunkcoordintpair, BiomeStorage biomestorage, ChunkConverter chunkconverter, TickList<Block> ticklist, TickList<FluidType> ticklist1, long i, @Nullable ChunkSection[] achunksection, @Nullable Consumer<Chunk> consumer) {
          this.sections = new ChunkSection[16];
          this.e = Maps.newHashMap();
-@@ -643,7 +659,7 @@ public class Chunk implements IChunkAccess {
+@@ -644,7 +660,7 @@ public class Chunk implements IChunkAccess {
          entity.chunkX = this.loc.x;
          entity.chunkY = k;
          entity.chunkZ = this.loc.z;
@@ -275,7 +275,7 @@ index 394765e2a0766002ea32ca816c0d95356d1caffb..cebce2a4029263ba0caf529196482c41
          this.entitySlices[k].add(entity); if (entity.hardCollides()) this.hardCollidingEntities[k].add(entity); // Tuinity - optimise hard colliding entities
          // Paper start
          if (entity instanceof EntityItem) {
-@@ -682,7 +698,7 @@ public class Chunk implements IChunkAccess {
+@@ -683,7 +699,7 @@ public class Chunk implements IChunkAccess {
              entity.entitySlice = null;
              entity.inChunk = false;
          }
@@ -284,7 +284,7 @@ index 394765e2a0766002ea32ca816c0d95356d1caffb..cebce2a4029263ba0caf529196482c41
              return;
          }
          if (entity instanceof EntityItem) {
-@@ -995,6 +1011,7 @@ public class Chunk implements IChunkAccess {
+@@ -996,6 +1012,7 @@ public class Chunk implements IChunkAccess {
  
      }
  
@@ -324,10 +324,10 @@ index 253377c6238594de1f76cafcbf8223592e4d3f6b..3ebe3d0dc4c2c6aee6ea349006a74cbe
          if (entityliving == entityliving1) {
              return false;
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 5bfc4db788bf63272211491a100ca5c69d77de44..e531faede1f3ae1160e690b93f7601c42f4c406c 100644
+index 6c3f496ba6c0c6c4911e2592ded27df08ae54b14..3ad08863c00d96c827c26c8d4c9a206a43bb1db9 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -1186,7 +1186,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -1187,7 +1187,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
                  Chunk chunk = (Chunk)this.getChunkIfLoadedImmediately(i1, j1); // Paper
  
                  if (chunk != null) {
@@ -336,7 +336,7 @@ index 5bfc4db788bf63272211491a100ca5c69d77de44..e531faede1f3ae1160e690b93f7601c4
                  }
              }
          }
-@@ -1209,7 +1209,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -1210,7 +1210,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
                  Chunk chunk = (Chunk)this.getChunkIfLoadedImmediately(i1, j1); // Paper
  
                  if (chunk != null) {
@@ -345,7 +345,7 @@ index 5bfc4db788bf63272211491a100ca5c69d77de44..e531faede1f3ae1160e690b93f7601c4
                  }
              }
          }
-@@ -1217,6 +1217,106 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -1218,6 +1218,106 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
          return list;
      }
  

--- a/patches/server/0049-Optimise-EntityInsentient-checkDespawn.patch
+++ b/patches/server/0049-Optimise-EntityInsentient-checkDespawn.patch
@@ -9,7 +9,7 @@ since the penalty of a map lookup could outweigh the benefits of
 searching less players (as it basically did in the outside range patch).
 
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index cebce2a4029263ba0caf529196482c41009beb1c..6fa33cd4a3e1181ad8fe2b3c9872951c5780e536 100644
+index 8c6c653b3454f59cf823fd92f7b464a8f998b675..781d74cf7e3669d71727cce781a8f8ce088c5547 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -157,6 +157,85 @@ public class Chunk implements IChunkAccess {
@@ -203,7 +203,7 @@ index 1cc9ec0377ce4f27ee1a9495b68325a29746c699..2861e46eb4d22346b4eeb167a023efed
      // Paper start - Chunk Prioritization
      public void queueHolderUpdate(PlayerChunk playerchunk) {
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index e531faede1f3ae1160e690b93f7601c42f4c406c..4a17c1b8092968247ee9fa0ce2b5bd44baf2b18f 100644
+index 3ad08863c00d96c827c26c8d4c9a206a43bb1db9..28ee325fcc8b50397768363403823f2e3391d8c8 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -123,6 +123,34 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
@@ -242,7 +242,7 @@ index e531faede1f3ae1160e690b93f7601c42f4c406c..4a17c1b8092968247ee9fa0ce2b5bd44
          this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((WorldDataServer) worlddatamutable).getName()); // Spigot
          this.paperConfig = new com.destroystokyo.paper.PaperWorldConfig(((WorldDataServer) worlddatamutable).getName(), this.spigotConfig); // Paper
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 271e456648ef428404291cf43e6989a7f3ee7f0b..a65a73d2f3f42862950b73b42e673ebdb6781a4e 100644
+index 9ec624ed52be2a6f6d06fbf1b7f928bb5fa4304e..623d020fe8620d51d5c54d76fdcf73be75625329 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -300,6 +300,10 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/patches/server/0050-Remove-streams-for-villager-AI.patch
+++ b/patches/server/0050-Remove-streams-for-villager-AI.patch
@@ -462,7 +462,7 @@ index a33303c31881b6391723e16a06d7841d48679958..ce57e6a4acac97d6da82202094306e7e
          return this.b.equals(entityliving.getEntityType()) && this.d.test(entityliving);
      }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index d6a4065424932cd66d995f12560d0d13d56c1493..06a94669539658a2045a96eeed2133eb8d9ba85a 100644
+index 65075ec384f839fa47e93458a942376f59472d6e..5d06eb3895094c33c2977070feffb46290cb766b 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -1609,6 +1609,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke

--- a/patches/server/0058-Copy-passenger-list-in-enderTeleportTo.patch
+++ b/patches/server/0058-Copy-passenger-list-in-enderTeleportTo.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Copy passenger list in enderTeleportTo
 Fixes https://github.com/Spottedleaf/Tuinity/issues/208
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 06a94669539658a2045a96eeed2133eb8d9ba85a..4eda7e81ce4f600082e118e2401b37a362b31597 100644
+index 5d06eb3895094c33c2977070feffb46290cb766b..957441e29ba34f90123660d2d180c9c025cd4a92 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
-@@ -3097,7 +3097,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -3103,7 +3103,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
              this.cp().forEach((entity) -> {
                  worldserver.chunkCheck(entity);
                  entity.az = true;

--- a/patches/server/0060-Prevent-light-queue-overfill-when-no-players-are-onl.patch
+++ b/patches/server/0060-Prevent-light-queue-overfill-when-no-players-are-onl.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Prevent light queue overfill when no players are online
 block changes don't queue light updates (and they shouldn't)
 
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 84429f12d0c6e0990b7cbb1b503b7868b3a02b14..12d9b73ccc2f4406957932397746cac7902d650e 100644
+index a44fbfaf42170e57729ecbc23e034d8745d45785..38ca1c042afd41a1f660f88e398fedde00f34e39 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-@@ -1220,7 +1220,7 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -1211,7 +1211,7 @@ public class ChunkProviderServer extends IChunkProvider {
              if (ChunkProviderServer.this.tickDistanceManager()) {
                  return true;
              } else {


### PR DESCRIPTION
Upstream has released updates that appears to apply and compile correctly

Paper Changes:
b109eef0d [CI-SKIP] [Auto] Rebuild Patches
9110bb8ee Fix villager boat exploit (#5047)
3148b25b1 [CI-SKIP] [Auto] Rebuild Patches
880a910a9 Properly track block update flags (actually fixes #5038)
ace3146df Fix debug stick update suppression (Fixes #5038)
bb4247f86 Fix dumpitem command not checking sender (#5025)
b72a74e48 nerf nether search radius config (#4781)
ce8922b1d clone POI blockpos before dispatching
4768e3c4e Optimize Loaded Chunks Cache Lookups