### PR TITLE
Fix packet limiter config

### DIFF
--- a/patches/server/0045-Add-packet-limiter-config.patch
+++ b/patches/server/0045-Add-packet-limiter-config.patch
@@ -24,7 +24,7 @@ and an action can be defined: DROP or KICK
 If interval or rate are less-than 0, the limit is ignored
 
 diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-index fdc56a5080ab2f7331431ee1f5976ba669b725ac..f15d84e082066c488cc3050119086ed21ed5fbe9 100644
+index fdc56a5080ab2f7331431ee1f5976ba669b725ac..29b89c244bb8a20bed1789bb7c5001739d3b6c3a 100644
 --- a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 +++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 @@ -1,6 +1,7 @@
@@ -35,7 +35,7 @@ index fdc56a5080ab2f7331431ee1f5976ba669b725ac..f15d84e082066c488cc3050119086ed2
  import net.minecraft.server.level.TicketType;
  import org.bukkit.Bukkit;
  import org.bukkit.configuration.ConfigurationSection;
-@@ -139,6 +140,91 @@ public final class TuinityConfig {
+@@ -139,6 +140,98 @@ public final class TuinityConfig {
          lagCompensateBlockBreaking = TuinityConfig.getBoolean("lag-compensate-block-breaking", true);
      }
  
@@ -88,13 +88,20 @@ index fdc56a5080ab2f7331431ee1f5976ba669b725ac..f15d84e082066c488cc3050119086ed2
 +            if (packetClassName.equals("all")) {
 +                continue;
 +            }
-+            final Class<?> packetClazz;
++            Class<?> packetClazz = null;
 +
 +            try {
 +                packetClazz = Class.forName(nmsPackage + "." + packetClassName);
 +            } catch (final ClassNotFoundException ex) {
-+                MinecraftServer.LOGGER.warn("Packet '" + packetClassName + "' does not exist, cannot limit it! Please update tuinity.yml");
-+                continue;
++                for (final String subpackage : java.util.Arrays.asList("game", "handshake", "login", "status")) {
++                    try {
++                        packetClazz = Class.forName("net.minecraft.network.protocol." + subpackage + "." + packetClassName);
++                    } catch (final ClassNotFoundException ignore) {}
++                }
++                if (packetClazz == null) {
++                    MinecraftServer.LOGGER.warn("Packet '" + packetClassName + "' does not exist, cannot limit it! Please update tuinity.yml");
++                    continue;
++                }
 +            }
 +
 +            if (!net.minecraft.network.protocol.Packet.class.isAssignableFrom(packetClazz)) {

--- a/patches/server/0045-Add-packet-limiter-config.patch
+++ b/patches/server/0045-Add-packet-limiter-config.patch
@@ -24,7 +24,7 @@ and an action can be defined: DROP or KICK
 If interval or rate are less-than 0, the limit is ignored
 
 diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-index fdc56a5080ab2f7331431ee1f5976ba669b725ac..36b1e95c964288843e0dd3c92704265759f8afb9 100644
+index fdc56a5080ab2f7331431ee1f5976ba669b725ac..f15d84e082066c488cc3050119086ed21ed5fbe9 100644
 --- a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 +++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 @@ -1,6 +1,7 @@
@@ -35,7 +35,7 @@ index fdc56a5080ab2f7331431ee1f5976ba669b725ac..36b1e95c964288843e0dd3c927042657
  import net.minecraft.server.level.TicketType;
  import org.bukkit.Bukkit;
  import org.bukkit.configuration.ConfigurationSection;
-@@ -139,6 +140,89 @@ public final class TuinityConfig {
+@@ -139,6 +140,91 @@ public final class TuinityConfig {
          lagCompensateBlockBreaking = TuinityConfig.getBoolean("lag-compensate-block-breaking", true);
      }
  
@@ -82,6 +82,8 @@ index fdc56a5080ab2f7331431ee1f5976ba669b725ac..36b1e95c964288843e0dd3c927042657
 +        TuinityConfig.getString("packet-limiter.limits." +
 +                net.minecraft.network.protocol.game.PacketPlayInAutoRecipe.class.getSimpleName() + ".action", PacketLimit.ViolateAction.DROP.name());
 +
++        final String canonicalName = MinecraftServer.class.getCanonicalName();
++        final String nmsPackage = canonicalName.substring(0, canonicalName.lastIndexOf("."));
 +        for (final String packetClassName : section.getKeys(false)) {
 +            if (packetClassName.equals("all")) {
 +                continue;
@@ -89,7 +91,7 @@ index fdc56a5080ab2f7331431ee1f5976ba669b725ac..36b1e95c964288843e0dd3c927042657
 +            final Class<?> packetClazz;
 +
 +            try {
-+                packetClazz = Class.forName("net.minecraft.server." + packetClassName);
++                packetClazz = Class.forName(nmsPackage + "." + packetClassName);
 +            } catch (final ClassNotFoundException ex) {
 +                MinecraftServer.LOGGER.warn("Packet '" + packetClassName + "' does not exist, cannot limit it! Please update tuinity.yml");
 +                continue;

--- a/patches/server/0061-Rewrite-the-light-engine.patch
+++ b/patches/server/0061-Rewrite-the-light-engine.patch
@@ -3706,10 +3706,10 @@ index 0000000000000000000000000000000000000000..0e4442a94559346b19a536d35ce5def6
 +    }
 +}
 diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-index 36b1e95c964288843e0dd3c92704265759f8afb9..e1ce8a5cec4c837fd2750480c92dc084cef6f4d9 100644
+index f15d84e082066c488cc3050119086ed21ed5fbe9..39738d71a97e391db44ecd45dc0fd15a365b7e49 100644
 --- a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 +++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-@@ -223,6 +223,12 @@ public final class TuinityConfig {
+@@ -225,6 +225,12 @@ public final class TuinityConfig {
          }
      }
  

--- a/patches/server/0061-Rewrite-the-light-engine.patch
+++ b/patches/server/0061-Rewrite-the-light-engine.patch
@@ -3706,10 +3706,10 @@ index 0000000000000000000000000000000000000000..0e4442a94559346b19a536d35ce5def6
 +    }
 +}
 diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-index f15d84e082066c488cc3050119086ed21ed5fbe9..39738d71a97e391db44ecd45dc0fd15a365b7e49 100644
+index 29b89c244bb8a20bed1789bb7c5001739d3b6c3a..85f6fba0ada92d5176a720761a7d4931c1259526 100644
 --- a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 +++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-@@ -225,6 +225,12 @@ public final class TuinityConfig {
+@@ -232,6 +232,12 @@ public final class TuinityConfig {
          }
      }
  

--- a/patches/server/0064-Send-full-pos-packets-for-hard-colliding-entities.patch
+++ b/patches/server/0064-Send-full-pos-packets-for-hard-colliding-entities.patch
@@ -9,10 +9,10 @@ Configurable under
 `send-full-pos-for-hard-colliding-entities`
 
 diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-index e1ce8a5cec4c837fd2750480c92dc084cef6f4d9..80a33d74e6c8ae44e8f1c94e32e90288973c2e47 100644
+index 39738d71a97e391db44ecd45dc0fd15a365b7e49..7a85741de82340c2964e23b7c7795a5440eecfdf 100644
 --- a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 +++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-@@ -229,6 +229,12 @@ public final class TuinityConfig {
+@@ -231,6 +231,12 @@ public final class TuinityConfig {
          useNewLightEngine = TuinityConfig.getBoolean("use-new-light-engine", true);
      }
  

--- a/patches/server/0064-Send-full-pos-packets-for-hard-colliding-entities.patch
+++ b/patches/server/0064-Send-full-pos-packets-for-hard-colliding-entities.patch
@@ -9,10 +9,10 @@ Configurable under
 `send-full-pos-for-hard-colliding-entities`
 
 diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-index 39738d71a97e391db44ecd45dc0fd15a365b7e49..7a85741de82340c2964e23b7c7795a5440eecfdf 100644
+index 85f6fba0ada92d5176a720761a7d4931c1259526..299b31ed429c922fcb6122e3c511bd16735e3c71 100644
 --- a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 +++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-@@ -231,6 +231,12 @@ public final class TuinityConfig {
+@@ -238,6 +238,12 @@ public final class TuinityConfig {
          useNewLightEngine = TuinityConfig.getBoolean("use-new-light-engine", true);
      }
  

--- a/patches/server/0076-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0076-Replace-player-chunk-loader-system.patch
@@ -1023,10 +1023,10 @@ index 0000000000000000000000000000000000000000..1fbd220b8a2c77ba85e98349b012b293
 +    }
 +}
 diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-index 80a33d74e6c8ae44e8f1c94e32e90288973c2e47..1f23b1002b517d0bdb9045553a3d1e707795ffed 100644
+index 7a85741de82340c2964e23b7c7795a5440eecfdf..ca9141f8e39ffcd89d677b4b0c400c03e2f7370b 100644
 --- a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 +++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-@@ -235,6 +235,25 @@ public final class TuinityConfig {
+@@ -237,6 +237,25 @@ public final class TuinityConfig {
          sendFullPosForHardCollidingEntities = TuinityConfig.getBoolean("send-full-pos-for-hard-colliding-entities", true);
      }
  

--- a/patches/server/0076-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0076-Replace-player-chunk-loader-system.patch
@@ -1023,10 +1023,10 @@ index 0000000000000000000000000000000000000000..1fbd220b8a2c77ba85e98349b012b293
 +    }
 +}
 diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-index 7a85741de82340c2964e23b7c7795a5440eecfdf..ca9141f8e39ffcd89d677b4b0c400c03e2f7370b 100644
+index 299b31ed429c922fcb6122e3c511bd16735e3c71..d0433feeb274f474af04ba1e09f9f75d5b4dcfea 100644
 --- a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 +++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-@@ -237,6 +237,25 @@ public final class TuinityConfig {
+@@ -244,6 +244,25 @@ public final class TuinityConfig {
          sendFullPosForHardCollidingEntities = TuinityConfig.getBoolean("send-full-pos-for-hard-colliding-entities", true);
      }
  


### PR DESCRIPTION
The new relocation pattern for flattening and relocating nms no longer relocates the string used in Class.forName in the packet limiter config